### PR TITLE
Disbable macos13 due to vim issues

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
         - ubuntu-22.04
         - ubuntu-20.04
         - macos-12
-        - macos-13
+        # - macos-13
         - macos-14
     steps:
     - name: Set up Git repository


### PR DESCRIPTION
Since I dont' run any macos 13 machines atm, this should be fine.