### PR TITLE
Use Hunk as Git diff pager

### DIFF
--- a/darwin/default.nix
+++ b/darwin/default.nix
@@ -154,7 +154,6 @@
       bashInteractive
       bat
       curl
-      delta
       fd
       jdk
       jq

--- a/darwin/homebrew.nix
+++ b/darwin/homebrew.nix
@@ -11,6 +11,7 @@ let
     homebrew-brew
     homebrew-cask
     homebrew-core
+    modem-homebrew-tap
     nix-homebrew
     ;
 in
@@ -39,6 +40,7 @@ in
       "logdy"
       "mactop"
       "mise"
+      "modem-dev/tap/hunk"
       "node"
       "ncdu"
       "opencode"
@@ -117,6 +119,7 @@ in
       "homebrew/homebrew-core" = homebrew-core;
       "homebrew/homebrew-cask" = homebrew-cask;
       "hashicorp/tap" = inputs.hashicorp-tap;
+      "modem-dev/tap" = modem-homebrew-tap;
       "xykong/tap" = inputs.xykong-tap;
     };
     mutableTaps = true;

--- a/flake.lock
+++ b/flake.lock
@@ -182,6 +182,22 @@
         "type": "github"
       }
     },
+    "modem-homebrew-tap": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1778435160,
+        "narHash": "sha256-GHi8SNnTeUl+PtRGXY1IhsXOvi+9Y7fBL0S/XjnDbOw=",
+        "owner": "modem-dev",
+        "repo": "homebrew-tap",
+        "rev": "194c65822ba503d7dc741c16878446a8d283145a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "modem-dev",
+        "repo": "homebrew-tap",
+        "type": "github"
+      }
+    },
     "nix-darwin": {
       "inputs": {
         "nixpkgs": [
@@ -279,6 +295,7 @@
         "homebrew-brew": "homebrew-brew",
         "homebrew-cask": "homebrew-cask",
         "homebrew-core": "homebrew-core",
+        "modem-homebrew-tap": "modem-homebrew-tap",
         "nix-darwin": "nix-darwin",
         "nix-homebrew": "nix-homebrew",
         "nixpkgs": "nixpkgs",

--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,10 @@
       url = "github:hashicorp/homebrew-tap";
       flake = false;
     };
+    modem-homebrew-tap = {
+      url = "github:modem-dev/homebrew-tap";
+      flake = false;
+    };
     nix-homebrew = {
       url = "github:zhaofengli/nix-homebrew";
     };

--- a/home/git.nix
+++ b/home/git.nix
@@ -74,6 +74,13 @@
       core = {
         mergeoptions = "--no-edit";
         editor = "nvim";
+        pager = "hunk pager";
+      };
+      pager = {
+        blame = "hunk pager";
+        diff = "hunk pager";
+        log = "hunk pager";
+        show = "hunk pager";
       };
       help.autocorrect = 1;
       diff.colorMoved = "default";
@@ -155,15 +162,13 @@
     ];
   };
 
-  programs.delta = {
-    enable = true;
-    enableGitIntegration = true;
-    options = {
-      navigate = true;
-      light = false;
-      line-numbers = true;
-    };
-  };
+  xdg.configFile."hunk/config.toml".text = ''
+    theme = "graphite"
+    mode = "auto"
+    exclude_untracked = false
+    line_numbers = true
+    wrap_lines = false
+  '';
 
   # gitui is now installed via Homebrew (see darwin/homebrew.nix)
 }

--- a/home/shell.nix
+++ b/home/shell.nix
@@ -116,7 +116,7 @@
         C-b w                   Open window selector
 
       Utilities (Home Manager + Flake)
-        bat, coreutils, curl, delta, direnv, eza, fd, fzf, git, jq, kubectx,
+        bat, coreutils, curl, direnv, eza, fd, fzf, git, hunk, jq, kubectx,
         nixfmt, ripgrep, starship, tree, wget, zoxide
       EOF
             }


### PR DESCRIPTION
## Summary
- add the pinned `modem-dev/homebrew-tap` input and manage `modem-dev/tap/hunk` through nix-homebrew
- remove Delta from the managed system package/Git integration path
- point Git's core and command-specific pagers at `hunk pager` and add a managed Hunk config

## Validation
- `nix flake check --all-systems --no-build`
- `pre-commit run --all-files`
- `git diff --check`
- `darwin-rebuild build --flake .#darwin-arm64`

## Notes
- `darwin-rebuild switch --flake .#darwin-arm64` still needs to be run with sudo locally to activate the config.