### PR TITLE
Trust Homebrew taps in CI

### DIFF
--- a/.github/workflows/nix-test.yaml
+++ b/.github/workflows/nix-test.yaml
@@ -63,16 +63,6 @@ jobs:
             brew untap $(brew tap) || true
           fi
 
-      - name: Trust Homebrew taps
-        run: |
-          if brew trust --help >/dev/null 2>&1; then
-            brew trust --tap \
-              hashicorp/tap \
-              mikesplain/omlx \
-              modem-dev/tap \
-              xykong/tap
-          fi
-
       - name: Test - Nix Run
         env:
           NIX_CONFIG: "access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/nix-test.yaml
+++ b/.github/workflows/nix-test.yaml
@@ -63,6 +63,16 @@ jobs:
             brew untap $(brew tap) || true
           fi
 
+      - name: Trust Homebrew taps
+        run: |
+          if brew trust --help >/dev/null 2>&1; then
+            brew trust --tap \
+              hashicorp/tap \
+              mikesplain/omlx \
+              modem-dev/tap \
+              xykong/tap
+          fi
+
       - name: Test - Nix Run
         env:
           NIX_CONFIG: "access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}"

--- a/darwin/homebrew.nix
+++ b/darwin/homebrew.nix
@@ -15,6 +15,7 @@ let
     modem-homebrew-tap
     nix-homebrew
     ;
+  brewBin = if platform.isArm then "/opt/homebrew/bin/brew" else "/usr/local/bin/brew";
 in
 {
   # Import the nix-homebrew module
@@ -129,4 +130,17 @@ in
     mutableTaps = true;
     autoMigrate = true;
   };
+
+  system.activationScripts.homebrew.text = lib.mkOrder 600 ''
+    # Trust managed non-official taps after nix-homebrew creates them and
+    # before nix-darwin runs Homebrew Bundle.
+    if [ -x "${brewBin}" ] && sudo --user=${lib.escapeShellArg user.name} --set-home "${brewBin}" trust --help >/dev/null 2>&1; then
+      echo >&2 "Trusting Homebrew taps..."
+      sudo --user=${lib.escapeShellArg user.name} --set-home "${brewBin}" trust --tap \
+        hashicorp/tap \
+        mikesplain/omlx \
+        modem-dev/tap \
+        xykong/tap
+    fi
+  '';
 }


### PR DESCRIPTION
## Summary
- Move Homebrew tap trust into the nix-darwin Homebrew activation script instead of a standalone workflow step.
- Order the trust block after `nix-homebrew` recreates the managed Homebrew prefix and before nix-darwin runs `brew bundle`.
- Trust the managed non-official taps: `hashicorp/tap`, `mikesplain/omlx`, `modem-dev/tap`, and `xykong/tap`.

## Root cause
The first attempt trusted taps before `darwin-rebuild`, but CI logs showed `nix-homebrew` then migrated/recreated Homebrew during activation. `brew bundle` subsequently failed on `modem-dev/tap/hunk` because the effective managed Homebrew setup still saw the tap as untrusted.

## Validation
- `git diff --check`
- `pre-commit run --files .github/workflows/nix-test.yaml darwin/homebrew.nix`
- Temporary CI-style eval confirmed activation order: setup Homebrew prefixes, trust Homebrew taps, then Homebrew bundle.
- Temporary CI-style `nix flake check --all-systems --no-build` with `defaultSystem=aarch64-darwin` and `defaultVersion=26`

Not run locally: the full macOS `darwin-rebuild` switch workflow.