### PR TITLE
Use explicit Python 3.14 Homebrew formula

### DIFF
--- a/darwin/homebrew.nix
+++ b/darwin/homebrew.nix
@@ -47,7 +47,7 @@ in
       "ncdu"
       "opencode"
       "pi-coding-agent"
-      "python"
+      "python@3.14"
       "ripgrep"
       "terraform-ls"
       "telnet"


### PR DESCRIPTION
## Summary
- Replace the Homebrew `python` alias in `darwin/homebrew.nix` with the explicit `python@3.14` formula.

## Why
PR #645 exposed a Homebrew Bundle failure after the flake update. The CI activation path attempted to fetch a formula named `python` and failed, while Homebrew's canonical current formula is `python@3.14`. This also matches the existing shell PATH setup for `python@3.14`.

## Validation
- `pre-commit run --files darwin/homebrew.nix`
- `nix flake check --all-systems --no-build`

## Risk / Rollback
Low risk: this keeps the same effective current Homebrew Python version, but avoids relying on alias resolution during activation. Roll back by changing the formula token back to `python` if Homebrew alias resolution is no longer an issue.