### PR TITLE
[codex] Remove direnv Darwin workaround

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -86,25 +86,6 @@
             overlays = [
               nur.overlays.default
               (final: prev: {
-                direnv =
-                  if prev.stdenv.isDarwin then
-                    prev.direnv.overrideAttrs (_old: {
-                      # Temporary Darwin workaround for flaky shell integration
-                      # checks while nixpkgs tracks the fish/zsh failures:
-                      # https://github.com/NixOS/nixpkgs/issues/507531
-                      nativeCheckInputs = [ prev.writableTmpDirAsHomeHook ];
-                      checkPhase = ''
-                        runHook preCheck
-
-                        make test-go test-bash
-
-                        runHook postCheck
-                      '';
-                    })
-                  else
-                    prev.direnv;
-              })
-              (final: prev: {
                 vscode-lldb-adapter =
                   if prev.stdenv.isDarwin && prev.stdenv.isx86_64 then
                     prev.vscode-lldb-adapter.override {


### PR DESCRIPTION
## What changed

Removes the local Darwin-only `direnv` override from the flake overlay so the configuration uses the locked nixpkgs `direnv` package directly.

## Why

The override was added while Darwin `direnv` builds were failing around shell integration tests. With the current lock, the upstream package evaluates and builds/fetches cleanly on `aarch64-darwin`, so this local workaround is no longer pulling its weight.

## Impact

This reduces local package customization and lets future nixpkgs updates carry the upstream `direnv` behavior normally.

## Validation

- `nix build --impure --no-link --expr 'let flake = builtins.getFlake "path:/Users/msplain/.dotfiles"; in flake.inputs.nixpkgs.legacyPackages.aarch64-darwin.direnv'`
- `pre-commit run --files flake.nix`
- `nix flake check --all-systems --no-build`