### PR TITLE
[codex] Remove vscode-lldb adapter override

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -85,15 +85,6 @@
             config.allowUnfree = true;
             overlays = [
               nur.overlays.default
-              (final: prev: {
-                vscode-lldb-adapter =
-                  if prev.stdenv.isDarwin && prev.stdenv.isx86_64 then
-                    prev.vscode-lldb-adapter.override {
-                      llvmPackages = prev.llvmPackages_18;
-                    }
-                  else
-                    prev.vscode-lldb-adapter;
-              })
             ];
           };
 


### PR DESCRIPTION
## What changed

Removes the local `vscode-lldb-adapter` overlay from `flake.nix`.

## Why

The override targeted a stale top-level package attribute. Current nixpkgs exposes the adapter under `vscode-extensions.vadimcn.vscode-lldb.adapter`, and that package now evaluates and builds without the local LLVM override.

## Impact

This reduces local flake customization and avoids carrying a dead override path for x86_64 Darwin.

## Validation

- `nix eval --impure --raw --expr 'let flake = builtins.getFlake "path:/Users/msplain/.dotfiles"; in flake.inputs.nixpkgs.legacyPackages.aarch64-darwin.vscode-extensions.vadimcn.vscode-lldb.adapter.version'`
- `nix build --impure --no-link --expr 'let flake = builtins.getFlake "path:/Users/msplain/.dotfiles"; in flake.inputs.nixpkgs.legacyPackages.aarch64-darwin.vscode-extensions.vadimcn.vscode-lldb.adapter'`
- `adapter_path=$(nix path-info --impure --expr 'let flake = builtins.getFlake "path:/Users/msplain/.dotfiles"; in flake.inputs.nixpkgs.legacyPackages.aarch64-darwin.vscode-extensions.vadimcn.vscode-lldb.adapter') && "$adapter_path/bin/codelldb" --help`
- `pre-commit run --files flake.nix`
- `nix flake check --all-systems --no-build`