### PR TITLE
[codex] Enable auto optimise store

### DIFF
--- a/darwin/default.nix
+++ b/darwin/default.nix
@@ -25,7 +25,8 @@
     # Prefer stable to maximize cache hits; latest can trigger full source builds/tests.
     package = pkgs.nixVersions.stable;
     settings = {
-      auto-optimise-store = false; # Disabled due to https://github.com/NixOS/nix/issues/7273#issuecomment-1325073957
+      # Deduplicate store files incrementally as paths are added.
+      auto-optimise-store = true;
       trusted-users = [ user.name ];
       max-jobs = 10;
       experimental-features = "nix-command flakes";


### PR DESCRIPTION
## What changed

Enables `nix.settings.auto-optimise-store` in the Darwin base configuration and replaces the stale bug workaround comment with a short note about incremental store deduplication.

## Why

The previous config explicitly disabled automatic optimisation because of an older Nix store race. That upstream issue is now resolved, and the current configuration uses Nix `2.34.7+1`, so the old workaround is no longer the default we want to encode.

## Impact

Nix will incrementally deduplicate identical store files as paths are added. This can reduce disk growth over time, especially with frequent flake updates, at the cost of a small amount of extra work during store additions.

## Validation

- `nix eval --json .#darwinConfigurations.darwin-arm64.config.nix.settings.auto-optimise-store`
- `pre-commit run --files darwin/default.nix`
- `nix flake check --all-systems --no-build`