### PR TITLE
fix(ci): migrate create-github-app-token from app-id to client-id

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -24,7 +24,7 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.RENOVATE_APP_ID }}
+          client-id: ${{ secrets.RENOVATE_CLIENT_ID }}
           private-key: ${{ secrets.RENOVATE_PEM }}
 
       - name: Checkout


### PR DESCRIPTION
## What

Replace deprecated `app-id` input with `client-id` in `actions/create-github-app-token@v3`.

## Why

GitHub Actions logs show:
```
##[warning]Input 'app-id' has been deprecated with message: Use 'client-id' instead.
```

## Required Action

This PR introduces a **new secret** `RENOVATE_CLIENT_ID`. Before merging, add it to the repo secrets:

1. Go to **Settings > Developer settings > Your GitHub App** (the one used for Renovate)
2. Copy the **Client ID** (looks like `Iv1.xxx`) — this is different from the numeric App ID
3. Add repo secret: **`RENOVATE_CLIENT_ID`** = that Client ID value

> The existing `RENOVATE_APP_ID` secret is no longer needed after this merges (can be cleaned up later).

## Changes

- `.github/workflows/renovate.yml`: `app-id: \${{ secrets.RENOVATE_APP_ID }}` → `client-id: \${{ secrets.RENOVATE_CLIENT_ID }}`