### PR TITLE
fix(renovate): remove global-only config options

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,13 +1,8 @@
 {
   "branchPrefix": "test-renovate/",
-  "dryRun": null,
-  "username": "private-renovatebot[bot]",
   "gitAuthor": "Private Renovatebot <123456+private-renovatebot[bot]@users.noreply.github.com>",
-  "onboarding": false,
   "configMigration": true,
-  "platform": "github",
   "forkProcessing": "disabled",
-  "repositories": ["mikesplain/dotfiles"],
   "prHourlyLimit": 20,
   "dependencyDashboard": true,
   "dependencyDashboardTitle": "Renovate Dashboard",


### PR DESCRIPTION
## What

Remove 5 global-only options from the repo-level `renovate.json`:

- `dryRun`
- `username`
- `onboarding`
- `platform`
- `repositories`

## Why

Renovate logs show:
```
WARN: Found renovate config warnings
  "The \\"dryRun\\" option is a global option reserved only for Renovate's global configuration and cannot be configured within a repository's config file."
  (same for onboarding, platform, repositories, username)
```

These are reserved for self-hosted global configs and are silently ignored in repo-level configs. Removing them clears the "Renovate Dashboard" (#148) warnings.