### PR TITLE
Move Prettier to Homebrew

### DIFF
--- a/darwin/homebrew.nix
+++ b/darwin/homebrew.nix
@@ -47,6 +47,7 @@ in
       "ncdu"
       "opencode"
       "pi-coding-agent"
+      "prettier"
       "python@3.14"
       "ripgrep"
       "terraform-ls"

--- a/home/neovim.nix
+++ b/home/neovim.nix
@@ -85,7 +85,6 @@ in
       vscode-langservers-extracted
       typescript
       typescript-language-server
-      prettier
       hclfmt
       jq
       yamlfmt


### PR DESCRIPTION
## Summary

- install Prettier through the existing Homebrew-managed Node toolchain
- remove Nix Prettier from Neovim extra packages

## Why

The flake update in #674 makes Nix reject `pnpm-9.15.9`, which is used only to build the Nix Prettier package and is marked insecure for multiple CVEs. Neovim still needs the `prettier` executable for JS, TS, CSS, HTML, and JSON formatting; Homebrew provides it without that vulnerable Nix build dependency.

## Validation

- `nix develop -c nix flake check`
- `nix develop -c pre-commit run --all-files`
- `sudo darwin-rebuild switch --flake .#personal-darwin-arm64`
- clean-shell `zsh` check resolved `/opt/homebrew/bin/prettier` (3.9.4)