### PR TITLE
Fix tmux terminal capability detection

### DIFF
--- a/home/shell.nix
+++ b/home/shell.nix
@@ -49,7 +49,6 @@
 
     sessionVariables = {
       SHELL = "${pkgs.zsh}/bin/zsh";
-      TERM = "xterm-256color";
       LESS = "-R";
     };
 

--- a/home/tmux.nix
+++ b/home/tmux.nix
@@ -2,7 +2,7 @@
 {
   programs.tmux = {
     enable = true;
-    terminal = "xterm-256color";
+    terminal = "tmux-256color";
     shell = "${pkgs.zsh}/bin/zsh";
     prefix = "C-b";
     escapeTime = 10;


### PR DESCRIPTION
## Problem

Pi and other terminal applications can receive incomplete or incorrect terminal capability information inside tmux.

The tmux server advertised `xterm-256color` to applications even though tmux requires a `screen` or `tmux` derivative. The shell also globally forced `TERM=xterm-256color`, overriding the value selected by Ghostty or tmux.

## Changes

- Advertise `tmux-256color` inside tmux panes.
- Stop globally overriding `TERM` in the zsh session environment.

This allows Ghostty and tmux to set the appropriate terminal identity and capability set, including clipboard and enhanced-key behavior used by Pi.

## Validation

- `pre-commit run --all-files`
- `nix flake check --all-systems --no-build`
- Evaluated the rendered Home Manager configuration and confirmed:
  - tmux terminal is `tmux-256color`
  - zsh session variables no longer contain `TERM`

## Rollout

Apply the Darwin configuration, then fully restart the tmux server so existing sessions do not retain the old terminal environment.

## Rollback

Revert this commit and rebuild the Darwin configuration.
